### PR TITLE
chore(ci): github actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zlubsen

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-    -   package-ecosystem: "cargo" # See documentation for possible values
-        directory: "/" # Location of package manifests
-        schedule:
-            interval: "weekly"
+    - package-ecosystem: "cargo"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,7 +68,10 @@ jobs:
               uses: dtolnay/rust-toolchain@master
               with:
                   toolchain: ${{ matrix.toolchain }}
-                  components: clippy, rustfmt, tarpaulin
+                  components: clippy, rustfmt
+            
+            - name: Setup Tarpaulin
+              run: cargo install cargo-tarpaulin
 
             - name: Setup Bun
               uses: oven-sh/setup-bun@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,100 @@
+name: check
+
+on:
+    push:
+        branches:
+            - development
+            - master
+        tags:
+            - v*
+    pull_request:
+        branches:
+            - development
+            - master
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+env:
+    RUSTFLAGS: "-Dwarnings"
+
+jobs:
+    semver:
+        name: Semantic Versioning
+        if: startsWith(github.ref_name, 'v')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Git tag is Semantic Versioning
+              env:
+                  DIS_RS_REF_NAME: ${{ github.ref_name }}
+              run: |
+                  _tag="$DIS_RS_REF_NAME"
+                  if ! printf "%s\n" "$_tag" | grep -q -P '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?$'; then
+                    printf '[ERROR]: Git tag (%s) wrong format\n' "$_tag"
+                    exit 1
+                  fi
+
+    check:
+        name: Build & Format & Lint & Test & Coverage
+        needs: semver
+        if: always() && (needs.semver.result == 'success' || needs.semver.result == 'skipped')
+        strategy:
+            fail-fast: true
+            matrix:
+                os:
+                    - macos-latest
+                    - ubuntu-latest
+                    - windows-latest
+                toolchain:
+                    - "1.74"
+                    - stable
+                profile:
+                    - dev
+                    - release
+        runs-on: ${{ matrix.os }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@master
+              with:
+                  toolchain: ${{ matrix.toolchain }}
+                  components: clippy, rustfmt, tarpaulin
+
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install Bun dependencies
+              working-directory: ./cdis-gateway
+              run: bun install
+
+            - name: Build
+              run: cargo build --profile ${{ matrix.profile }} --verbose --all-features --all-targets --workspace
+
+            - name: Format
+              run: cargo fmt --verbose --check --all
+
+            - name: Lint
+              run: cargo clippy --profile ${{ matrix.profile }} --verbose --all-features --all-targets --all
+
+            - name: Test
+              run: cargo test --profile ${{ matrix.profile }} --verbose --all-features --all-targets --workspace
+
+            - name: Coverage
+              run: cargo tarpaulin --profile ${{ matrix.profile }} --verbose --all-features --all-targets --workspace --out xml
+
+            - name: Upload coverage
+              uses: codecov/codecov-action@v4
+              with:
+                  fail_ci_if_error: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -101,6 +101,6 @@ jobs:
 
             - name: Upload coverage
               if: matrix.toolchain == 'stable'
-              uses: codecov/codecov-action@v4
+              uses: codecov/codecov-action@v5
               with:
-                  fail_ci_if_error: true
+                token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,6 +71,7 @@ jobs:
                   components: clippy, rustfmt
             
             - name: Setup Tarpaulin
+              if: matrix.toolchain == 'stable'
               run: cargo install cargo-tarpaulin
 
             - name: Setup Bun
@@ -95,9 +96,11 @@ jobs:
               run: cargo test --profile ${{ matrix.profile }} --verbose --all-features --all-targets --workspace
 
             - name: Coverage
+              if: matrix.toolchain == 'stable'
               run: cargo tarpaulin --profile ${{ matrix.profile }} --verbose --all-features --all-targets --workspace --out xml
 
             - name: Upload coverage
+              if: matrix.toolchain == 'stable'
               uses: codecov/codecov-action@v4
               with:
                   fail_ci_if_error: true

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,22 @@
+name: license
+
+on:
+    schedule:
+        - cron: "0 0 1 1 *"
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: true
+
+jobs:
+    license:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - uses: FantasticFiasco/action-update-license-year@v3
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: release
+
+on:
+    workflow_run:
+        workflows:
+            - check
+        types:
+            - completed
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: true
+
+env:
+    RUSTFLAGS: "-Dwarnings"
+
+jobs:
+    release:
+        name: Release
+        runs-on: ubuntu-latest
+        if: github.event.workflow_run.conclusion == 'success' && github.ref_name == 'master' && startsWith(github.event.workflow_run.head_branch, 'v')
+        permissions:
+            contents: write
+            id-token: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.workflow_run.head_branch }}
+
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@master
+              with:
+                  toolchain: stable
+
+            # TODO changelog & GitHub release
+
+            - name: Publish
+              run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --verbose --package dis-rs

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ Thumbs.db
 
 # Log
 *.log
+
+# Coverage
+cobertura.xml
+tarpaulin-report.html

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "bierner.markdown-emoji",
         "EditorConfig.EditorConfig",
         "fill-labs.dependi",
+        "GitHub.vscode-github-actions",
         "Gruntfuggly.todo-tree",
         "rust-lang.rust-analyzer",
         "tamasfe.even-better-toml",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DIS for Rust
 
+[![release](https://github.com/zlubsen/dis-rs/actions/workflows/release.yml/badge.svg)](https://github.com/zlubsen/dis-rs/actions/workflows/release.yml)
+
 `dis-rs` is a suite of libraries and applications centered around the Distributed Interactive Simulation protocol (IEEE 1278.1), implemented in the Rust programming language and for use in Rust-based simulation applications.
 
 This repository hosts a number of sub-projects, each located in a specific directory:


### PR DESCRIPTION
Fix #44
Fix #49

First iteration, integrating `GitHub Actions`

- Fixed `dependabot` checking both `Rust` and `GitHub Actions`
- Added `CODEOWNERS`
- Workflow `license` to automatically update license year
- Workflow `check` to Build, Format, Lint, Coverage
  **For coverage to work create an account https://about.codecov.io and link `dis-rs` repository**
- Workflow `release` to automatically release to `Crates` if a `Semantic Versioning` tag is pushed.
  **Add to the repository the secret token `CARGO_REGISTRY_TOKEN`**

**NOTE 1: CI fails because all warning are treated as errors**, see PR #53 
**NOTE 2: Only `dis-rs` is published**