### PR TITLE
Fix signal parser padding

### DIFF
--- a/dis-rs/src/common/signal/mod.rs
+++ b/dis-rs/src/common/signal/mod.rs
@@ -10,6 +10,7 @@ mod tests {
     use crate::common::parser::parse_pdu;
     use crate::enumerations::{PduType, SignalEncodingClass, SignalEncodingType};
     use crate::model::EntityId;
+    use crate::parser::parse_multiple_pdu;
     use crate::signal::model::{EncodingScheme, Signal};
     use bytes::BytesMut;
 
@@ -44,6 +45,47 @@ mod tests {
         match parsed {
             Ok(ref pdu) => {
                 assert_eq!(&original_pdu, pdu);
+            }
+            Err(ref err) => {
+                panic!("Parse error: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn signal_test_padding_parsing() {
+        let header = PduHeader::new_v6(1, PduType::Signal);
+
+        let body = Signal::builder()
+            .with_encoding_scheme(EncodingScheme::EncodedAudio {
+                encoding_class: SignalEncodingClass::EncodedAudio,
+                encoding_type: SignalEncodingType::_16bitLinearPCM2sComplement_BigEndian_4,
+            })
+            .with_samples(20)
+            .with_sample_rate(20000)
+            .with_radio_number(10)
+            .with_radio_reference_id(EntityId::new(10, 10, 123))
+            .with_data(vec![0x10, 0x10, 0x10])
+            .build()
+            .into_pdu_body();
+        let original_pdu =
+            Pdu::finalize_from_parts(header, body, DisTimeStamp::new_absolute_from_secs(100));
+        let pdu_length = original_pdu.header.pdu_length;
+        let original_length = original_pdu.pdu_length();
+
+        let mut buf = BytesMut::with_capacity(pdu_length as usize);
+
+        let serialized_length = original_pdu.serialize(&mut buf).unwrap();
+
+        let two_signals = [buf.clone(), buf.clone()].concat();
+
+        assert_eq!(original_length, serialized_length);
+
+        let parsed = parse_multiple_pdu(two_signals.as_slice());
+        match parsed {
+            Ok(ref pdu) => {
+                assert_eq!(&original_pdu, &pdu[0]);
+                assert_eq!(&original_pdu, &pdu[1]);
             }
             Err(ref err) => {
                 panic!("Parse error: {err}");


### PR DESCRIPTION
I noticed that this library's signal pdu parser doesn't quite follow the DIS standard for padding, as the variable data in signal PDUs are defined slightly differently than the standard 'variable datum' data type. In the Data field definition for signal pdus, the following is stated:

> The length of the valid data contained in this field shall be the value of the Data Length field. The
Data field shall be zero-padded to ensure overall PDU length compliance

and in the field size table for the Signal pdu has the following:

> Total Signal PDU size = 256 + Data Length + 0 to 31 padding bits to increase the total Signal
PDU size to a multiple of 32 bits.

This means that the 'data length' field of the signal pdu's value doesn't include the padding bits, and a padding needs to be calculated and skipped on top of that 'data length' if neccesary. Currently it seems as though the parser assumes that the data length includes the padding bits, as it does not skip any padding bits in the parser code. 