### PR TITLE
fix: clamp marking strings to field width when serializing

### DIFF
--- a/dis-rs/src/common/aggregate_state/writer.rs
+++ b/dis-rs/src/common/aggregate_state/writer.rs
@@ -75,11 +75,10 @@ impl Serialize for AggregateType {
 impl Serialize for AggregateMarking {
     fn serialize(&self, buf: &mut BytesMut) -> u16 {
         buf.put_u8(self.marking_character_set.into());
-        let num_pad = 31 - self.marking_string.len();
-        let marking = self.marking_string.clone(); // clone necessary because into_bytes consumes self.
-
-        buf.put_slice(&marking.into_bytes()[..]);
-        (0..num_pad).for_each(|_i| buf.put_u8(0x20));
+        let bytes = self.marking_string.as_bytes();
+        let len = bytes.len().min(31);
+        buf.put_slice(&bytes[..len]);
+        buf.put_bytes(0x20, 31 - len);
 
         self.record_length()
     }
@@ -106,5 +105,28 @@ impl Serialize for SilentEntitySystem {
             .sum::<u16>();
 
         self.record_length()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Serialize;
+    use crate::aggregate_state::model::AggregateMarking;
+    use crate::enumerations::EntityMarkingCharacterSet;
+    use bytes::BytesMut;
+
+    #[test]
+    fn aggregate_marking_longer_than_field_is_clamped() {
+        let marking = AggregateMarking {
+            marking_character_set: EntityMarkingCharacterSet::ASCII,
+            marking_string: "A".repeat(40), // 40 > 31
+        };
+        let mut buf = BytesMut::with_capacity(32);
+
+        marking.serialize(&mut buf);
+
+        // Charset byte + 31 marking bytes = 32-octet field; must not panic/overflow.
+        assert_eq!(buf.len(), 32);
+        assert!(buf[1..].iter().all(|&b| b == b'A'));
     }
 }

--- a/dis-rs/src/common/entity_state/writer.rs
+++ b/dis-rs/src/common/entity_state/writer.rs
@@ -141,11 +141,10 @@ impl Serialize for EntityType {
 impl Serialize for EntityMarking {
     fn serialize(&self, buf: &mut BytesMut) -> u16 {
         buf.put_u8(self.marking_character_set.into());
-        let num_pad = 11 - self.marking_string.len();
-        let marking = self.marking_string.clone(); // clone necessary because into_bytes consumes self.
-
-        buf.put_slice(&marking.into_bytes()[..]);
-        (0..num_pad).for_each(|_i| buf.put_u8(0x20));
+        let bytes = self.marking_string.as_bytes();
+        let len = bytes.len().min(11);
+        buf.put_slice(&bytes[..len]);
+        buf.put_bytes(0x20, 11 - len);
         12
     }
 }
@@ -185,6 +184,23 @@ mod tests {
 
         let expected: [u8; 12] = [
             0x01, 0x45, 0x59, 0x45, 0x20, 0x31, 0x30, 0x20, 0x20, 0x20, 0x20, 0x20,
+        ];
+        assert_eq!(buf.as_ref(), expected.as_ref());
+    }
+
+    #[test]
+    fn entity_marking_longer_than_field_is_clamped() {
+        let marking = EntityMarking {
+            marking_character_set: EntityMarkingCharacterSet::ASCII,
+            marking_string: "ABCDEFGHIJKLMN".to_string(), // 14 > 11
+        };
+        let mut buf = BytesMut::with_capacity(12);
+
+        marking.serialize(&mut buf);
+
+        // Charset byte + first 11 marking bytes, no padding; must not panic/overflow.
+        let expected: [u8; 12] = [
+            0x01, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b,
         ];
         assert_eq!(buf.as_ref(), expected.as_ref());
     }


### PR DESCRIPTION
## Summary

`EntityMarking::serialize` and `AggregateMarking::serialize` underflow when the
marking string is longer than the fixed DIS field (11 and 31 octets
respectively).

Both compute padding as an unsigned subtraction:

```rust
// entity_state/writer.rs
let num_pad = 11 - self.marking_string.len();
// aggregate_state/writer.rs
let num_pad = 31 - self.marking_string.len();
```

When `marking_string.len()` exceeds the field width, `num_pad` wraps to
~`usize::MAX`, and the `(0..num_pad)` loop tries to write that many padding
bytes. (Separately, `put_slice` writes the full over-length string, overflowing
the fixed-size field even before the padding step.)

## Impact

- **Debug builds:** panic; `attempt to subtract with overflow`.
- **Release builds:** the subtraction wraps and the writer attempts to push
  ~2⁶⁴ padding bytes into the `BytesMut`, causing unbounded memory growth /
  OOM, and the call never returns.

`EntityMarking::new_ascii` / `new` accept a string of any length without
validation, so this is reachable from safe, ordinary use. Any marking longer
than the field triggers it.

## Reproducer

```rust
use bytes::BytesMut;
use dis_rs::Serialize;
use dis_rs::entity_state::model::EntityMarking;

let marking = EntityMarking::new_ascii("ABCDEFGHIJKLMN"); // 14 > 11
let mut buf = BytesMut::new();
marking.serialize(&mut buf); // panics (debug) / OOMs (release)
```

## Fix

Clamp the written bytes to the field width and derive the pad count from the
clamped length, so the serialized field is always exactly its spec size
(12 / 32 octets including the character-set byte) regardless of input:

```rust
let bytes = self.marking_string.as_bytes();
let len = bytes.len().min(11); // 31 for AggregateMarking
buf.put_slice(&bytes[..len]);
buf.put_bytes(0x20, 11 - len);
```

This keeps the existing behavior for in-spec markings and truncates over-length markings instead
of overflowing. 

## Tests

Added `entity_marking_longer_than_field_is_clamped` and
`aggregate_marking_longer_than_field_is_clamped`. Full `dis-rs` suite passes
(208 tests), clippy and rustfmt clean.